### PR TITLE
Debug Print Updates

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ include $(DEVKITARM)/3ds_rules
 #     - <libctru folder>/default_icon.png
 #---------------------------------------------------------------------------------
 APP_TITLE   :=  Majoras Mask 3D Randomizer
-APP_AUTHOR  :=  Tacoman369/PhlexPlexico
+APP_AUTHOR  :=  Tacoman369
 APP_DESCRIPTION:= A Randomized Majora's Mask 
 TARGET		:=	$(notdir $(CURDIR))
 BUILD		:=	build

--- a/Makefile
+++ b/Makefile
@@ -32,8 +32,8 @@ include $(DEVKITARM)/3ds_rules
 #     - <libctru folder>/default_icon.png
 #---------------------------------------------------------------------------------
 APP_TITLE   :=  Majoras Mask 3D Randomizer
-APP_AUTHOR  :=  Tacoman369
-APP_DESCRIPTION:= A Randomized Majoras Mask 
+APP_AUTHOR  :=  Tacoman369/PhlexPlexico
+APP_DESCRIPTION:= A Randomized Majora's Mask 
 TARGET		:=	$(notdir $(CURDIR))
 BUILD		:=	build
 SOURCES		:=	source
@@ -193,8 +193,9 @@ endif
 #---------------------------------------------------------------------------------
 clean:
 	@echo Cleaning app and basecode ...
-	@rm -fr $(BUILD) $(TARGET).3dsx $(OUTPUT).smdh $(TARGET).elf $(GFXBUILD) $(ROMFS)/basecode.ips
-	$(MAKE) -f mm3dr/code/Makefile clean
+	@rm -fr $(BUILD) $(TARGET).3dsx $(OUTPUT).smdh $(TARGET).elf $(GFXBUILD) $(ROMFS)/basecode.ips source/include/patch_symbols.hpp
+	$(MAKE) clean -f mm3dr/code/Makefile
+	@rm -rf mm3dr/code/build
 	
 #---------------------------------------------------------------------------------
 $(GFXBUILD)/%.t3x	$(BUILD)/%.h	:	%.t3s

--- a/source/debug.cpp
+++ b/source/debug.cpp
@@ -1,7 +1,19 @@
 #include "debug.hpp"
 
 #include <3ds.h>
+#include <cstdio>
+#include <cstdarg>
 
 void CitraPrint (std::string_view str) {
    svcOutputDebugString(str.data(), str.length());
+}
+
+void DebugPrint(const char *format, ...) {
+    char buffer[0x200];
+    va_list arg;
+    va_start(arg, format);
+    const int written = vsnprintf(buffer, sizeof(buffer), format, arg);
+    va_end(arg);
+    if (written >= 0)
+      svcOutputDebugString(buffer, sizeof(buffer));
 }

--- a/source/include/debug.hpp
+++ b/source/include/debug.hpp
@@ -3,3 +3,4 @@
 #include <string_view>
 
 void CitraPrint(std::string_view str);
+void DebugPrint(const char *format, ...);


### PR DESCRIPTION
_Clearly_ the better CitraPrint call because variable replacement is easier /s

However there is a subrepo update in this PR as well, to fix some build issues that I was experiencing and others may run into as well, since it's unused code in the subrepo with a bad `#define`s.

Also cleanup the build directory in the subrepo as well, as it wasn't getting cleaned initially so let's just force it for now.